### PR TITLE
Fixed indentation on primes.py code block.

### DIFF
--- a/python_profiler.md
+++ b/python_profiler.md
@@ -36,31 +36,31 @@ After you have installed the `line_profiler` module, to use it you need to add a
 Let's take a simple example, a script to calculate the first `n` prime numbers (this is saved as `primes.py`):
 
 ```
- def primes(n):
-     if n==2:
-         return [2]
-     elif n<2:
-         return []
+def primes(n):
+    if n==2:
+        return [2]
+    elif n<2:
+        return []
 
-     s=range(3,n+1,2)
-     mroot = n ** 0.5
-     half=(n+1)/2-1
-     i=0
-     m=3
+    s=range(3,n+1,2)
+    mroot = n ** 0.5
+    half=(n+1)/2-1
+    i=0
+    m=3
 
-     while m <= mroot:
-         if s[i]:
-             j=(m*m-3)/2
-             s[j]=0
-             while j<half:
-                 s[j]=0
-                 j+=m
-         i=i+1
-         m=2*i+3
-     return [2]+[x for x in s if x]
+    while m <= mroot:
+        if s[i]:
+            j=(m*m-3)/2
+            s[j]=0
+            while j<half:
+                s[j]=0
+                j+=m
+        i=i+1
+        m=2*i+3
+    return [2]+[x for x in s if x]
 
- primes(100)
- ```
+primes(100)
+```
 
 To profile the `primes` function, we need to add the `@profile` decorator before the function:
 


### PR DESCRIPTION
primes.py code snippet featured an extra character of whitespace at the start each line. This prevented direct copy and pasting into the learner's IDE. This is now addressed.
