### PR TITLE
Modified primes.py so that it works with Python 3 and Python 2.

### DIFF
--- a/python_profiler.md
+++ b/python_profiler.md
@@ -44,7 +44,7 @@ Let's take a simple example, a script to calculate the first `n` prime numbers (
 
      s=list(range(3,n+1,2))
      mroot = n ** 0.5
-     half=(n+1)/2-1
+     half=(n+1)//2-1
      i=0
      m=3
 

--- a/python_profiler.md
+++ b/python_profiler.md
@@ -42,7 +42,7 @@ Let's take a simple example, a script to calculate the first `n` prime numbers (
      elif n<2:
          return []
 
-     s=range(3,n+1,2)
+     s=list(range(3,n+1,2))
      mroot = n ** 0.5
      half=(n+1)/2-1
      i=0
@@ -50,7 +50,7 @@ Let's take a simple example, a script to calculate the first `n` prime numbers (
 
      while m <= mroot:
          if s[i]:
-             j=(m*m-3)/2
+             j=(m*m-3)//2
              s[j]=0
              while j<half:
                  s[j]=0


### PR DESCRIPTION
The original example requires Python 2. Many people use Python 3 now, and `line_profiler` supports Python 3 - so it would be best if the example worked with both versions of Python.

Perhaps there should also be some explicit text in the lesson to reassure students that it works with both versions?
